### PR TITLE
Add Netrw config

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -36,6 +36,10 @@ vim.opt.updatetime = 50
 vim.g.mapleader = " "
 vim.keymap.set("n", "<leader>pv", vim.cmd.Ex)
 
+--[[ Netrw ]]
+vim.g.netrw_keepdir = 0
+vim.g.netrw_localmovecmd = "mv"
+
 --[[ Package manager ]]
 return require("packer").startup(function()
   -- Package manager


### PR DESCRIPTION
Netrw 上で mark した上で mv したときに

```
**error** (netrw) tried using g:netrw_localcopycmd<mv>; it doesn't work!
```

のエラーがでたため、追加。

ref:
- [Tips : vimのnetrwファイラでファイルを移動する](https://zenn.dev/takatom/articles/3cf0c20a0ce8ba)
- [Copying files with Vim's netrw on Mac OS X is broken](https://stackoverflow.com/questions/31811335/copying-files-with-vims-netrw-on-mac-os-x-is-broken)