### PR TITLE
Add telescope-kensaku plugin and load Telescope extension

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -384,6 +384,16 @@ require("lazy").setup({
     end,
   },
   {
+    "Allianaab2m/telescope-kensaku.nvim",
+    dependencies = {
+      "vim-denops/denops.vim",
+      "lambdalisue/vim-kensaku",
+    },
+    config = function()
+      require("telescope").load_extension("kensaku")
+    end,
+  },
+  {
     "nvimdev/lspsaga.nvim",
     commit = "a958783bc9d86217a4200845cd950314857636f3",
     dependencies = { "neovim/nvim-lspconfig" },


### PR DESCRIPTION
### Motivation
- Enable the `Allianaab2m/telescope-kensaku.nvim` extension for Telescope to provide kensaku-based searching.
- Ensure required runtime integration via Denops and the original `vim-kensaku` plugin so the extension works correctly.

### Description
- Added a new plugin entry for `Allianaab2m/telescope-kensaku.nvim` in `init.lua`.
- Declared dependencies `vim-denops/denops.vim` and `lambdalisue/vim-kensaku` for the plugin.
- Configured Telescope to load the extension with `require("telescope").load_extension("kensaku")`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957646e94088331aec4f8b38d1c0f84)