### PR TITLE
Add copy path keymaps

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -35,6 +35,12 @@ vim.opt.updatetime = 50
 --[[ Keymap ]]
 vim.g.mapleader = " "
 vim.keymap.set("n", "<leader>pv", vim.cmd.Ex)
+vim.keymap.set("n", "<leader>cp", function()
+  vim.fn.setreg("+", vim.fn.expand("%:p"))
+end, { desc = "Copy full path" })
+vim.keymap.set("n", "<leader>cr", function()
+  vim.fn.setreg("+", vim.fn.expand("%"))
+end, { desc = "Copy relative path" })
 
 --[[ Netrw ]]
 vim.g.netrw_localmovecmd = "mv"

--- a/docs/NEOVIM.md
+++ b/docs/NEOVIM.md
@@ -10,6 +10,11 @@ Leader is set to `Space`.
 
 - `Space + pv`: Open netrw file explorer.
 
+## Clipboard
+
+- `Space + cp`: Copy full path.
+- `Space + cr`: Copy relative path.
+
 ## Git (gitsigns.nvim)
 
 Navigation


### PR DESCRIPTION
## Summary
- Add keymaps to copy full/relative file paths.
- Document the new keymaps in Neovim docs.

## Testing
- Not run (bun scripts not defined: lint/build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut to copy the current file's full path to clipboard.
  * Added keyboard shortcut to copy the current file's relative path to clipboard.

* **Documentation**
  * Updated Neovim documentation with new clipboard command reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->