### PR TITLE
chore(shell): set default editor to nvim

### DIFF
--- a/.zshrc.d/00-env.zsh
+++ b/.zshrc.d/00-env.zsh
@@ -1,3 +1,3 @@
-export EDITOR=vim
+export EDITOR=nvim
 export TERM=screen-256color
 export PNPM_HOME="$HOME/Library/pnpm"


### PR DESCRIPTION
## Summary
- change default editor from vim to nvim in shell env
- this makes tools that use $EDITOR (including lazygit edit action) open Neovim

## Verification
- confirmed  now exports 
- runtime reload in user shell is required ( or new terminal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default editor configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->