### PR TITLE
fix: avoid duplicate tmux session names in tms

### DIFF
--- a/.zshrc.d/40-functions.zsh
+++ b/.zshrc.d/40-functions.zsh
@@ -20,6 +20,14 @@ function tms() {
   local -a parts
 
   name="${name// /_}"
+  name="${name//:/_}"
+  if [[ "$name" == .* ]]; then
+    name="_${name#.}"
+  fi
+  if [[ -z "$name" ]]; then
+    name="_"
+  fi
+
   if ! tmux has-session -t "$name" 2>/dev/null; then
     tmux new -s "$name"
     return
@@ -34,6 +42,14 @@ function tms() {
     candidate="${(j:/:)parts[$start,$count]}"
     candidate="${candidate//\//__}"
     candidate="${candidate// /_}"
+    candidate="${candidate//:/_}"
+    if [[ "$candidate" == .* ]]; then
+      candidate="_${candidate#.}"
+    fi
+    if [[ -z "$candidate" ]]; then
+      candidate="_"
+    fi
+
     if ! tmux has-session -t "$candidate" 2>/dev/null; then
       tmux new -s "$candidate"
       return
@@ -42,6 +58,14 @@ function tms() {
 
   full_candidate="${(j:__:)parts}"
   full_candidate="${full_candidate// /_}"
+  full_candidate="${full_candidate//:/_}"
+  if [[ "$full_candidate" == .* ]]; then
+    full_candidate="_${full_candidate#.}"
+  fi
+  if [[ -z "$full_candidate" ]]; then
+    full_candidate="_"
+  fi
+
   candidate="${full_candidate}-${suffix}"
   while tmux has-session -t "$candidate" 2>/dev/null; do
     suffix=$((suffix + 1))

--- a/.zshrc.d/40-functions.zsh
+++ b/.zshrc.d/40-functions.zsh
@@ -9,7 +9,44 @@ zle -N peco-history-selection
 bindkey '^R' peco-history-selection
 
 function tms() {
-  local name="${PWD##*/}"
+  local cwd="${PWD:A}"
+  local name="${cwd##*/}"
+  local candidate=""
+  local full_candidate=""
+  local start=1
+  local count=0
+  local i=0
+  local suffix=2
+  local -a parts
+
   name="${name// /_}"
-  tmux new -s "$name"
+  if ! tmux has-session -t "$name" 2>/dev/null; then
+    tmux new -s "$name"
+    return
+  fi
+
+  parts=("${(@s:/:)cwd}")
+  parts=("${parts[@]:#}")
+  count=${#parts[@]}
+
+  for ((i = 2; i <= count; i++)); do
+    start=$((count - i + 1))
+    candidate="${(j:/:)parts[$start,$count]}"
+    candidate="${candidate//\//__}"
+    candidate="${candidate// /_}"
+    if ! tmux has-session -t "$candidate" 2>/dev/null; then
+      tmux new -s "$candidate"
+      return
+    fi
+  done
+
+  full_candidate="${(j:__:)parts}"
+  full_candidate="${full_candidate// /_}"
+  candidate="${full_candidate}-${suffix}"
+  while tmux has-session -t "$candidate" 2>/dev/null; do
+    suffix=$((suffix + 1))
+    candidate="${full_candidate}-${suffix}"
+  done
+
+  tmux new -s "$candidate"
 }


### PR DESCRIPTION
## Summary
- update `tms` to check existing tmux sessions before creating a new one
- if the leaf directory name already exists, expand the session name with parent directories
- replace `/` with `__` (and spaces with `_`) for tmux-safe session names
- add numeric suffix fallback when expanded names still collide

## Verification
- `zsh -n .zshrc.d/40-functions.zsh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Session naming now derives from the full directory path with deterministic sanitization (handles spaces, slashes, dots, colons).
  * Automatic conflict detection: checks for existing sessions and picks the first available progressive path-based name.
  * If collisions persist, falls back to a full-path base with an incrementing numeric suffix for uniqueness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->