### PR TITLE
feat(nvim): add directory-scoped live grep keymaps

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -380,6 +380,21 @@ require("lazy").setup({
         builtin.find_files({ no_ignore = true })
       end, { desc = "Find all files (including gitignored)" })
       vim.keymap.set("n", "<leader>fg", builtin.live_grep, {})
+      vim.keymap.set("n", "<leader>fG", function()
+        local dir = vim.fn.input("Dir: ", "", "dir")
+        if dir ~= "" then
+          builtin.live_grep({ search_dirs = { dir } })
+        end
+      end, { desc = "Live grep in directory" })
+      vim.keymap.set("n", "<leader>fA", function()
+        local dir = vim.fn.input("Dir (all): ", "", "dir")
+        if dir ~= "" then
+          builtin.live_grep({
+            search_dirs = { dir },
+            additional_args = { "--hidden", "--no-ignore", "--glob=!.git/" },
+          })
+        end
+      end, { desc = "Live grep in directory (include hidden/ignored)" })
       vim.keymap.set("n", "<leader>fb", builtin.buffers, {})
       vim.keymap.set("n", "<leader>fh", builtin.help_tags, {})
 


### PR DESCRIPTION
## Summary
- Add `<leader>fG` for directory-scoped `live_grep` (respects `.gitignore`)
- Add `<leader>fA` for directory-scoped `live_grep` including hidden/ignored files (excludes `.git/`)

## Test plan
- [ ] Open Neovim and press `<leader>fG`, enter a directory path, confirm grep works within that directory
- [ ] Press `<leader>fA`, enter a directory path, confirm hidden/ignored files are included
- [ ] Cancel input (empty string) and confirm no error occurs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new keyboard shortcuts for scoped text search: one for searching within a specified directory, and another for searching including hidden files while excluding `.git/` directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->