### PR TITLE
Support Homebrew setup without casks

### DIFF
--- a/.bin/install.sh
+++ b/.bin/install.sh
@@ -1,36 +1,55 @@
 #!/usr/bin/env zsh
 set -ue
 
+SCRIPT_NAME="${0:t}"
+
 helpmsg() {
-  command echo "Usage: $0 [--help | -h | init | brew | link | debug]" 0>&2
+  command echo "Usage: $SCRIPT_NAME [--help | -h | --debug | init [brew-options] | brew [brew-options] | link]" 0>&2
+  command echo "" 0>&2
+  command echo "Brew options:" 0>&2
+  command echo "  --no-cask     Skip GUI apps and fonts from Brewfile.casks" 0>&2
+  command echo "  --with-cask   Install GUI apps and fonts from Brewfile.casks (default)" 0>&2
   command echo ""
 }
 
-SCRIPT_DIR="$(cd "$(dirname $0)" && pwd -P)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 
-while [ $# -gt 0 ];do
+if [ $# -eq 0 ]; then
+  helpmsg
+  exit 1
+fi
+
+while [ $# -gt 0 ]; do
   case ${1} in
     --debug|-d)
       set -uex
+      shift
       ;;
     --help|-h)
       helpmsg
-      exit 1
+      exit 0
       ;;
     init)
+      shift
       "$SCRIPT_DIR/install_init.sh"
-      "$SCRIPT_DIR/install_brew.sh"
+      "$SCRIPT_DIR/install_brew.sh" "$@"
       "$SCRIPT_DIR/install_link.sh"
       # git config --global include.path "~/.gitconfig_shared"
       command echo -e "\e[1;36m Install completed!!!! \e[m"
+      exit 0
       ;;
     brew)
-      "$SCRIPT_DIR/install_brew.sh"
+      shift
+      "$SCRIPT_DIR/install_brew.sh" "$@"
+      exit 0
       ;;
     link)
+      shift
       "$SCRIPT_DIR/install_link.sh"
+      exit 0
       ;;
     debug)
+      shift
       ;;
     *)
       command echo "Invalid option: ${1}" 1>&2
@@ -38,6 +57,4 @@ while [ $# -gt 0 ];do
       exit 1
       ;;
   esac
-  shift
 done
-

--- a/.bin/install.sh
+++ b/.bin/install.sh
@@ -4,12 +4,12 @@ set -ue
 SCRIPT_NAME="${0:t}"
 
 helpmsg() {
-  command echo "Usage: $SCRIPT_NAME [--help | -h | --debug | init [brew-options] | brew [brew-options] | link]" 0>&2
-  command echo "" 0>&2
-  command echo "Brew options:" 0>&2
-  command echo "  --no-cask     Skip GUI apps and fonts from Brewfile.casks" 0>&2
-  command echo "  --with-cask   Install GUI apps and fonts from Brewfile.casks (default)" 0>&2
-  command echo ""
+  command echo "Usage: $SCRIPT_NAME [--help | -h | --debug | init [brew-options] | brew [brew-options] | link]" 1>&2
+  command echo "" 1>&2
+  command echo "Brew options:" 1>&2
+  command echo "  --no-cask     Skip GUI apps and fonts from Brewfile.casks" 1>&2
+  command echo "  --with-cask   Install GUI apps and fonts from Brewfile.casks (default)" 1>&2
+  command echo "" 1>&2
 }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"

--- a/.bin/install_brew.sh
+++ b/.bin/install_brew.sh
@@ -4,11 +4,11 @@ set -ue
 SCRIPT_NAME="${0:t}"
 
 helpmsg() {
-  command echo "Usage: $SCRIPT_NAME [--no-cask | --with-cask | --help]" 0>&2
-  command echo "" 0>&2
-  command echo "Installs Homebrew formulae from Brewfile." 0>&2
-  command echo "By default, also installs GUI apps and fonts from Brewfile.casks." 0>&2
-  command echo "Set DOTFILES_SKIP_BREW_CASKS=1 or pass --no-cask to skip casks." 0>&2
+  command echo "Usage: $SCRIPT_NAME [--no-cask | --with-cask | --help]" 1>&2
+  command echo "" 1>&2
+  command echo "Installs Homebrew formulae from Brewfile." 1>&2
+  command echo "By default, also installs GUI apps and fonts from Brewfile.casks." 1>&2
+  command echo "Set DOTFILES_SKIP_BREW_CASKS=1 or pass --no-cask to skip casks." 1>&2
 }
 
 INSTALL_CASKS=true

--- a/.bin/install_brew.sh
+++ b/.bin/install_brew.sh
@@ -1,9 +1,47 @@
 #!/usr/bin/env zsh
 set -ue
 
+SCRIPT_NAME="${0:t}"
+
+helpmsg() {
+  command echo "Usage: $SCRIPT_NAME [--no-cask | --with-cask | --help]" 0>&2
+  command echo "" 0>&2
+  command echo "Installs Homebrew formulae from Brewfile." 0>&2
+  command echo "By default, also installs GUI apps and fonts from Brewfile.casks." 0>&2
+  command echo "Set DOTFILES_SKIP_BREW_CASKS=1 or pass --no-cask to skip casks." 0>&2
+}
+
+INSTALL_CASKS=true
+
+if [[ "${DOTFILES_SKIP_BREW_CASKS:-}" == "1" ]]; then
+  INSTALL_CASKS=false
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-cask|--no-casks)
+      INSTALL_CASKS=false
+      ;;
+    --with-cask|--with-casks)
+      INSTALL_CASKS=true
+      ;;
+    --help|-h)
+      helpmsg
+      exit 0
+      ;;
+    *)
+      command echo "Invalid option for install_brew.sh: $1" 1>&2
+      helpmsg
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 DOT_DIR=$(dirname "${SCRIPT_DIR}")
 BREWFILE="$DOT_DIR/Brewfile"
+BREWFILE_CASKS="$DOT_DIR/Brewfile.casks"
 
 if which brew >/dev/null 2>&1; then
   echo "Homebrew is already installed."
@@ -18,15 +56,30 @@ brew doctor || echo "Warning: brew doctor found issues, but continuing..."
 echo "Run brew update..."
 brew update || echo "Warning: brew update failed, but continuing..."
 
-echo "Run brew upgrade..."
-brew upgrade || echo "Warning: brew upgrade failed, but continuing..."
+if [ "$INSTALL_CASKS" = true ]; then
+  echo "Run brew upgrade..."
+  brew upgrade || echo "Warning: brew upgrade failed, but continuing..."
+else
+  echo "Run brew upgrade --formula..."
+  brew upgrade --formula || echo "Warning: brew upgrade --formula failed, but continuing..."
+fi
 
 if [ -f "$BREWFILE" ]; then
-  echo "Installing packages from Brewfile..."
+  echo "Installing command-line packages from Brewfile..."
   brew bundle --file="$BREWFILE"
 else
   echo "Warning: Brewfile not found at $BREWFILE"
 fi
 
-brew cleanup || echo "Warning: brew cleanup failed, but continuing..."
+if [ "$INSTALL_CASKS" = true ]; then
+  if [ -f "$BREWFILE_CASKS" ]; then
+    echo "Installing GUI apps and fonts from Brewfile.casks..."
+    brew bundle --file="$BREWFILE_CASKS"
+  else
+    echo "Warning: Brewfile.casks not found at $BREWFILE_CASKS"
+  fi
+else
+  echo "Skipping Homebrew casks. Run '$SCRIPT_NAME --with-cask' later to install them."
+fi
 
+brew cleanup || echo "Warning: brew cleanup failed, but continuing..."

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@
 
 !/bootstrap.sh
 !/Brewfile
+!/Brewfile.casks
 !/README.md
 !/AGENTS.md
 !/docs/

--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,5 @@
 tap "bufbuild/buf" # Buf toolchain for Protocol Buffers
 tap "homebrew/bundle" # Brewfile support
-tap "homebrew/cask-fonts" # Font casks
-tap "homebrew/cask-versions" # Alternate cask versions
 tap "homebrew/services" # Homebrew services
 
 tap "reviewdog/tap" # reviewdog tools
@@ -51,16 +49,3 @@ brew "tmux" # terminal multiplexer
 brew "tree" # directory tree listing
 brew "reviewdog/tap/reviewdog" # review tool for CI
 brew "yukiarrr/tap/ecsk" # custom CLI tool (ecsk)
-
-cask "bitwarden" # password manager
-cask "coteditor" # macOS text editor
-cask "docker-desktop" # Docker GUI and engine
-cask "font-hack-nerd-font" # Hack Nerd Font
-cask "font-hackgen" # HackGen font
-cask "font-ricty-diminished" # Ricty Diminished font
-cask "google-chrome" # web browser
-cask "iterm2" # terminal emulator
-cask "ngrok" # tunneling tool
-cask "slack" # team chat
-cask "visual-studio-code" # code editor
-cask "zoom" # video meetings

--- a/Brewfile.casks
+++ b/Brewfile.casks
@@ -1,0 +1,15 @@
+tap "homebrew/cask-fonts" # Font casks
+tap "homebrew/cask-versions" # Alternate cask versions
+
+cask "bitwarden" # password manager
+cask "coteditor" # macOS text editor
+cask "docker-desktop" # Docker GUI and engine
+cask "font-hack-nerd-font" # Hack Nerd Font
+cask "font-hackgen" # HackGen font
+cask "font-ricty-diminished" # Ricty Diminished font
+cask "google-chrome" # web browser
+cask "iterm2" # terminal emulator
+cask "ngrok" # tunneling tool
+cask "slack" # team chat
+cask "visual-studio-code" # code editor
+cask "zoom" # video meetings

--- a/Brewfile.casks
+++ b/Brewfile.casks
@@ -1,6 +1,3 @@
-tap "homebrew/cask-fonts" # Font casks
-tap "homebrew/cask-versions" # Alternate cask versions
-
 cask "bitwarden" # password manager
 cask "coteditor" # macOS text editor
 cask "docker-desktop" # Docker GUI and engine

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ For a brand new Mac without Git installed, use the bootstrap script:
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/gentamura/dotfiles/main/bootstrap.sh)"
 ```
 
+To bootstrap without Homebrew casks:
+
+```bash
+DOTFILES_INSTALL_ARGS="init --no-cask" bash -c "$(curl -fsSL https://raw.githubusercontent.com/gentamura/dotfiles/main/bootstrap.sh)"
+```
+
 This script will:
 1. Check and install Command Line Tools (includes Git)
 2. Clone this repository to `~/dotfiles`
@@ -30,6 +36,12 @@ cd ~/dotfiles
 .bin/install.sh init
 ```
 
+For a managed/company Mac where Homebrew casks are restricted:
+
+```bash
+.bin/install.sh init --no-cask
+```
+
 ## Installation Components
 
 ### Full Installation
@@ -42,6 +54,14 @@ This runs all installation steps:
 1. Command Line Tools check/installation
 2. Homebrew installation and package setup
 3. Dotfiles symlinking
+
+By default this installs both command-line tools from `Brewfile` and GUI apps/fonts
+from `Brewfile.casks`. To install only command-line tools such as `neovim`, `rg`,
+`gh`, `tmux`, and `jq`, pass `--no-cask`:
+
+```bash
+.bin/install.sh init --no-cask
+```
 
 ### Individual Components
 
@@ -65,12 +85,27 @@ Checks if Command Line Tools are installed and installs them if needed.
 .bin/install_brew.sh
 ```
 
-Installs Homebrew (if needed) and all packages defined in `Brewfile`, including:
+Installs Homebrew (if needed), command-line packages defined in `Brewfile`, and
+GUI apps/fonts defined in `Brewfile.casks`, including:
 - Development tools (git, gh, neovim, tmux, etc.)
 - Programming languages (rust, openjdk, etc.)
 - Databases (postgresql, mysql, mongodb)
 - Applications (Docker Desktop, iTerm2, VS Code, etc.)
 - Security tools (git-secrets)
+
+To skip casks:
+
+```bash
+.bin/install.sh brew --no-cask
+# or directly
+.bin/install_brew.sh --no-cask
+```
+
+You can also set `DOTFILES_SKIP_BREW_CASKS=1` for non-interactive setup:
+
+```bash
+DOTFILES_SKIP_BREW_CASKS=1 .bin/install.sh init
+```
 
 #### Dotfiles Linking
 
@@ -126,7 +161,7 @@ See [.claude/CLAUDE.md](.claude/CLAUDE.md), [AGENTS.md](AGENTS.md) and [.claude/
 
 ### Development Tools
 
-See `Brewfile` for the complete list of installed tools and applications.
+See `Brewfile` for command-line tools and `Brewfile.casks` for GUI apps and fonts.
 
 ### Tmux + Lazygit Workflow
 
@@ -181,6 +216,7 @@ dotfiles/
 │   ├── install_brew.sh   # Homebrew and packages installation
 │   └── install_link.sh   # Dotfiles symlinking
 ├── Brewfile              # Homebrew packages definition
+├── Brewfile.casks        # Homebrew cask applications and fonts
 ├── AGENTS.md             # Shared agent entrypoint for local AI coding agents
 ├── skills/               # Shared skills (used by Codex and Claude)
 ├── .claude/              # Claude-specific configuration

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,6 +10,7 @@ NC='\033[0m' # No Color
 
 DOTFILES_REPO="https://github.com/gentamura/dotfiles.git"
 DOTFILES_DIR="$HOME/dotfiles"
+DOTFILES_INSTALL_ARGS="${DOTFILES_INSTALL_ARGS:-init}"
 
 echo -e "${CYAN}======================================${NC}"
 echo -e "${CYAN}  dotfiles Bootstrap Script${NC}"
@@ -94,7 +95,8 @@ run_installation() {
   cd "$DOTFILES_DIR"
 
   if [ -f ".bin/install.sh" ]; then
-    .bin/install.sh init
+    read -r -a install_args <<< "$DOTFILES_INSTALL_ARGS"
+    .bin/install.sh "${install_args[@]}"
   else
     echo -e "${RED}✗ Installation script not found${NC}"
     exit 1


### PR DESCRIPTION
## Summary
- split Homebrew casks into Brewfile.casks
- add --no-cask/--with-cask options for init and brew install flows
- document company Mac and bootstrap usage for cask-free setup

## Verification
- zsh -n .bin/install.sh
- zsh -n .bin/install_brew.sh
- bash -n bootstrap.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-cask` and `--with-cask` options to installation script for conditional Homebrew GUI app installation.
  * Environment variable `DOTFILES_SKIP_BREW_CASKS` now controls cask installation behavior.
  * Installation options are now customizable via environment variables without editing scripts.

* **Documentation**
  * Updated README with installation examples for restricted macOS setups and new cask workflows.

* **Chores**
  * Separated Homebrew GUI apps and fonts into `Brewfile.casks`; command-line tools remain in `Brewfile`.
  * Improved installation script help text and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->