### PR TITLE
chore: remove flutter/dart plugins from nvim config

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -595,24 +595,6 @@ require("lazy").setup({
       })
     end,
   },
-  {
-    "akinsho/flutter-tools.nvim",
-    dependencies = {
-      "nvim-lua/plenary.nvim",
-      "stevearc/dressing.nvim",
-    },
-    config = function()
-      require("flutter-tools").setup({})
-    end,
-  },
-  {
-    "dart-lang/dart-vim-plugin",
-    ft = { "dart" },
-    init = function()
-      vim.g.dart_style_guide = 2
-      vim.g.dart_format_on_save = 1
-    end,
-  },
 }, {
   defaults = {
     lazy = false,

--- a/.gitconfig
+++ b/.gitconfig
@@ -28,9 +28,6 @@
 [diff]
   colorMoved = default
 
-[hub] # https://github.com/github/hub
-  protocol = https
-
 [delta] # https://github.com/dandavison/delta
   navigate = true    # use n and N to move between diff sections
   light = false      # set to true if you're in a terminal w/ a light background color (e.g. the default macOS terminal)


### PR DESCRIPTION
## Summary
- Drop `flutter-tools.nvim` and `dart-vim-plugin` plugin definitions from `init.lua` (no longer used)

`lazy-lock.json` is gitignored and will be cleaned up automatically on next `:Lazy sync`.

## Test plan
- [ ] `nvim` opens without errors and `:Lazy` no longer lists flutter-tools / dart-vim-plugin
- [ ] No remaining references: `rg -i 'flutter|dart' .config/nvim/init.lua` returns no matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Flutter and Dart development tool plugins from Neovim editor configuration.
  * Removed GitHub hub integration from Git configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->