### PR TITLE
chore: split gitconfig into shared and personal layers

### DIFF
--- a/.bin/install_link.sh
+++ b/.bin/install_link.sh
@@ -200,6 +200,27 @@ if [[ "$HOME" != "$DOT_DIR" ]]; then
     command echo "Linked: $LAZYGIT_CONFIG_DEST -> $LAZYGIT_CONFIG_SRC"
   fi
 
+  # ~/.gitconfig: do not own the file, only ensure it includes ~/.gitconfig_shared.
+  # Migrate any legacy symlink (older installs symlinked ~/.gitconfig to dotfiles).
+  GITCONFIG_HOME="$HOME/.gitconfig"
+  if [ -L "$GITCONFIG_HOME" ]; then
+    command echo "Found legacy ~/.gitconfig symlink, backing up..."
+    command mv "$GITCONFIG_HOME" "$HOME/.dotbackup/.gitconfig_${TIMESTAMP}"
+  fi
+
+  if command git config --global --get-all include.path 2>/dev/null | command grep -Fxq "~/.gitconfig_shared"; then
+    command echo "~/.gitconfig already includes ~/.gitconfig_shared"
+  else
+    command git config --global --add include.path "~/.gitconfig_shared"
+    command echo "Added include.path = ~/.gitconfig_shared to ~/.gitconfig"
+  fi
+
+  if ! command git config --global user.name >/dev/null 2>&1 || ! command git config --global user.email >/dev/null 2>&1; then
+    command echo "Note: set your git identity if not already configured:"
+    command echo "  git config --global user.name 'Your Name'"
+    command echo "  git config --global user.email 'you@example.com'"
+  fi
+
   # Obsidian Vim config
   OBSIDIAN_VAULT_DIR="$HOME/Documents/Obsidian Vault"
   OBSIDIAN_VIMRC_SRC="$DOT_DIR/.config/obsidian/.obsidian.vimrc"

--- a/.bin/install_link.sh
+++ b/.bin/install_link.sh
@@ -208,10 +208,15 @@ if [[ "$HOME" != "$DOT_DIR" ]]; then
     command mv "$GITCONFIG_HOME" "$HOME/.dotbackup/.gitconfig_${TIMESTAMP}"
   fi
 
-  if command git config --global --get-all include.path 2>/dev/null | command grep -Fxq "~/.gitconfig_shared"; then
+  # Treat tilde and absolute forms as equivalent: git expands ~ at read time,
+  # but stores the literal string, so both representations can coexist.
+  GITCONFIG_SHARED_TILDE="~/.gitconfig_shared"
+  GITCONFIG_SHARED_ABS="$HOME/.gitconfig_shared"
+  EXISTING_INCLUDES="$(command git config --global --get-all include.path 2>/dev/null || true)"
+  if command printf '%s\n' "$EXISTING_INCLUDES" | command grep -Fxq -e "$GITCONFIG_SHARED_TILDE" -e "$GITCONFIG_SHARED_ABS"; then
     command echo "~/.gitconfig already includes ~/.gitconfig_shared"
   else
-    command git config --global --add include.path "~/.gitconfig_shared"
+    command git config --global --add include.path "$GITCONFIG_SHARED_TILDE"
     command echo "Added include.path = ~/.gitconfig_shared to ~/.gitconfig"
   fi
 

--- a/.gitconfig_shared
+++ b/.gitconfig_shared
@@ -1,13 +1,6 @@
-[user]
-  name = Gen Tamura
-  email = gen.tamura84@gmail.com
-
 [core]
   excludesfile = ~/.gitignore_global
   pager = delta
-
-[include]
-  path = ~/.gitconfig_shared
 
 [interactive]
   diffFilter = delta --color-only

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@
 !/.claude/README.md
 !/skills/
 !/skills/**
-!/.gitconfig
+!/.gitconfig_shared
 !/.gitignore_global
 
 !/bootstrap.sh

--- a/README.md
+++ b/README.md
@@ -140,11 +140,33 @@ EOF
 ln -snf ~/dotfiles/.zshrc.local ~/.zshrc.local
 ```
 
+#### Git Configuration
+
+Shared Git settings live in `.gitconfig_shared` and are symlinked to
+`~/.gitconfig_shared`. Personal settings (name, email, signing keys, etc.)
+belong in your own `~/.gitconfig`, which `install_link.sh` does **not**
+overwrite.
+
+`install_link.sh` idempotently adds the include directive:
+
+```ini
+# ~/.gitconfig
+[include]
+  path = ~/.gitconfig_shared
+```
+
+Set your identity once (or rely on the warning printed by `install_link.sh`):
+
+```bash
+git config --global user.name "Your Name"
+git config --global user.email "you@example.com"
+```
+
 ## What's Included
 
 ### Configuration Files
 
-- `.gitconfig` - Git configuration
+- `.gitconfig_shared` - Shared Git settings (included from `~/.gitconfig`)
 - `.config/mise/` - Mise tool configuration
 - `.config/nvim/.stylua.toml` - Lua formatting configuration (scoped to nvim)
 
@@ -234,7 +256,7 @@ dotfiles/
 │   ├── agents/           # Role-based agents
 │   ├── commands/         # Slash commands
 ├── .config/              # Application configurations
-├── .gitconfig            # Git configuration
+├── .gitconfig_shared     # Shared Git settings (included from ~/.gitconfig)
 └── README.md             # This file
 ```
 


### PR DESCRIPTION
## Summary
Reshape `.gitconfig` so the repo no longer owns each user's personal Git identity. The repo now provides only a **shared** layer; individual settings (name, email, signing keys) stay in each user's own `~/.gitconfig`.

- Rename `.gitconfig` → `.gitconfig_shared`; drop `[user]` and the self-include
- `install_link.sh` symlinks `~/.gitconfig_shared` and idempotently adds `[include] path = ~/.gitconfig_shared` to `~/.gitconfig`
- Migrate any legacy `~/.gitconfig` symlink (from older installs) to `~/.dotbackup`
- Warn when `user.name` / `user.email` are unset
- Update `.gitignore` allowlist and README

Reference: https://qiita.com/yutkat/items/c6c7584d9795799ee164

## Migration notes for existing users
Anyone whose `~/.gitconfig` is currently symlinked to the dotfiles repo will hit a dangling symlink the moment this PR is pulled. After merging:

1. `git pull`
2. `.bin/install_link.sh` (creates `~/.gitconfig_shared`, bootstraps `~/.gitconfig`)
3. `git config --global user.name "Your Name"` and `user.email`

## Test plan
- [ ] `git config --get core.pager` returns `delta` (shared include resolves)
- [ ] `git config --get-all include.path` lists `~/.gitconfig_shared` exactly once after re-running `install_link.sh`
- [ ] Fresh machine without `~/.gitconfig` gets a usable file after `install_link.sh`
- [ ] `zsh -n .bin/install_link.sh` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Git Configuration section with setup guidance and identity configuration instructions.
  * Updated documentation to reflect the new shared configuration approach.

* **Chores**
  * Installation process now manages and migrates Git configuration automatically.
  * Setup will prompt for Git identity credentials if not yet configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->